### PR TITLE
feat: update Unstop registration link

### DIFF
--- a/src/components/CardsParallax.tsx
+++ b/src/components/CardsParallax.tsx
@@ -192,7 +192,7 @@ export function CardsParallax() {
           </div>
 
           <a
-            href="https://unstop.com/p/tcet-shastras-competitive-programming-competition-2026-thakur-college-of-engineering-and-technology-tcet-mumbai-1631441"
+            href="https://unstop.com/o/gc8MVwn?lb=EPXO7qEG&utm_medium=Share&utm_source=tcetcod19106&utm_campaign=Online_coding_challenge"
             className="px-6 py-3 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl shadow-md"
           >
             Register Now

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -187,7 +187,7 @@ int main() {
 
               {/* Action Button */}
               <div className="pt-2">
-                <a id="hero-register" href="https://unstop.com/p/tcet-shastras-competitive-programming-competition-2026-thakur-college-of-engineering-and-technology-tcet-mumbai-1631441" target="_blank" rel="noopener noreferrer">
+                <a id="hero-register" href="https://unstop.com/o/gc8MVwn?lb=EPXO7qEG&utm_medium=Share&utm_source=tcetcod19106&utm_campaign=Online_coding_challenge" target="_blank" rel="noopener noreferrer">
                   <Button size="sm" className="w-full bg-[#f97316] text-white hover:bg-[#e55f10]">
                     Register Now
                   </Button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -110,7 +110,7 @@ export function Navbar() {
           {/* Register Button */}
           <a
             id="site-register"
-            href="https://unstop.com/p/tcet-shastras-competitive-programming-competition-2026-thakur-college-of-engineering-and-technology-tcet-mumbai-1631441"
+            href="https://unstop.com/o/gc8MVwn?lb=EPXO7qEG&utm_medium=Share&utm_source=tcetcod19106&utm_campaign=Online_coding_challenge"
           >
             <Button size="sm" className="rounded-lg bg-[#f97316] px-5 text-white shadow-md hover:bg-[#e55f10] active:scale-[0.98] transition-all duration-200">
               Register


### PR DESCRIPTION
Replace old Unstop event link with new shortened link across all components.
- Updated CardsParallax.tsx registration button
- Updated Hero.tsx main registration CTA
- Updated Navbar.tsx navigation register button